### PR TITLE
Fixes output with % characters under Ruby 2.5.0

### DIFF
--- a/lib/process_helper.rb
+++ b/lib/process_helper.rb
@@ -98,7 +98,7 @@ module ProcessHelper
             ch = stdout_and_stderr.read_nonblock(1)
           end
           break unless ch
-          printf ch if always_puts_output
+          printf format_char(ch) if always_puts_output
           output += ch
           stdout_and_stderr.flush
         end
@@ -126,6 +126,10 @@ module ProcessHelper
     # TODO: Why do we sometimes get here with no EOFError occurring, but instead
     # via IO::WaitReadable with a nil select result? (via popen, not sure if via tty)
     output
+  end
+
+  def format_char(ch)
+    ch == '%' ? '%%' : ch
   end
 
   def handle_timeout_error(output, options, seconds = nil, additional_msg = nil)

--- a/spec/output_handling_spec.rb
+++ b/spec/output_handling_spec.rb
@@ -34,6 +34,15 @@ RSpec.describe 'output handling' do
         .and(not_output.to_stderr)
   end
 
+  it 'escapes non-format % characters' do
+    expect do
+      clazz.process(
+        'echo %',
+        puts_output: :always)
+    end.to output("%\n").to_stdout
+      .and(not_output.to_stderr)
+  end
+
   describe 'when :puts_output == :never' do
     describe 'when include_output_in_exception is false' do
       it 'show warning' do


### PR DESCRIPTION
Newer rubies conform with BSD printf, where calling `printf "%"` errors out. This will escape printed % characters. Note that calling `process('printf %d')` will now print a literal `%d`.

Signed-off-by: Jeff Turley <jturley@pivotal.io>